### PR TITLE
test: update lock viewers annotation test

### DIFF
--- a/bigbluebutton-tests/playwright/user/lockViewers.js
+++ b/bigbluebutton-tests/playwright/user/lockViewers.js
@@ -201,6 +201,7 @@ class LockViewers extends MultiUsers {
     await this.userPage2.hasElement(e.whiteboard);
     await sleep(1000);   // timeout to ensure the user2 presentation is zoomed correctly
     await this.userPage2.wasRemoved(e.wbDrawnArrow, 'should not display the other viewer annotation for the viewer who just joined');
+    await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
     await expect(user2WbLocator, 'should not display the other viewer annotation for the viewer who just joined').toHaveScreenshot('viewer2-just-joined.png', screenshotOptions);
 
@@ -208,6 +209,7 @@ class LockViewers extends MultiUsers {
     await this.userPage.waitAndClick(e.wbShapesButton);
     await this.userPage.waitAndClick(e.wbRectangleShape);
     await this.userPage.waitAndClick(e.whiteboard);
+    await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
     await this.userPage2.wasRemoved(e.wbDrawnShape, 'should not display the new annotation for the other viewer');
     await expect(user2WbLocator, 'should not display the new annotation for the other viewer').toHaveScreenshot('viewer2-no-rectangle.png', screenshotOptions);
@@ -219,10 +221,13 @@ class LockViewers extends MultiUsers {
     // check if previous annotations is displayed after unlocking user
     await this.userPage2.hasElement(e.wbDrawnArrow, 'should display the arrow drawn before user join');
     await this.userPage2.hasElement(e.wbDrawnShape, 'should display the rectangle drawn before unlocking user');
+    await this.modPage.getLocator(e.chatButton).hover();
+    await this.userPage2.getLocator(e.chatButton).hover(); // ensure userPage cursor won't be visible on the screenshot
     await expect(user2WbLocator, 'should display the other viewer annotations when unlocking specific user').toHaveScreenshot('viewer2-previous-shapes.png', screenshotOptions);
 
     // check if new annotations is displayed after unlocking user
     await drawArrow(this.userPage);
+    await this.modPage.getLocator(e.chatButton).hover();
     await this.userPage.getLocator(e.chatButton).hover(); // ensure userPage cursor will be visible on the screenshot
     await this.userPage2.checkElementCount(e.wbDrawnArrow, 2, 'should display all arrows drawn for unlocked user');
     await expect(user2WbLocator, 'should display all arrows drawn for unlocked user').toHaveScreenshot('viewer2-new-arrow.png', screenshotOptions);


### PR DESCRIPTION
Adds a hover for the moderator, so the cursor doesn't show on the snapshot.